### PR TITLE
Ajustes en depuración y mejoras en jugabilidad

### DIFF
--- a/dday.vcxproj.user
+++ b/dday.vcxproj.user
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LocalDebuggerCommand>C:\quake2\dedicated</LocalDebuggerCommand>
+    <LocalDebuggerCommand>C:\Quake2\q2proded.exe</LocalDebuggerCommand>
     <LocalDebuggerCommandArguments>+set developer 1 +set game dday +set deathmatch 1 +exec server.cfg +set port 27911</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerWorkingDirectory>C:\quake2\</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>C:\Quake2\</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LocalDebuggerCommand>C:\quake2\dedicated</LocalDebuggerCommand>

--- a/g_save.c
+++ b/g_save.c
@@ -318,11 +318,11 @@ void InitGame(void)
 
 	g_select_empty = gi.cvar("g_select_empty", "0", CVAR_ARCHIVE);
 
-	run_pitch = gi.cvar("run_pitch", "0.002", 0);
-	run_roll = gi.cvar("run_roll", "0.005", 0);
-	bob_up = gi.cvar("bob_up", "0.005", 0);
-	bob_pitch = gi.cvar("bob_pitch", "0.002", 0);
-	bob_roll = gi.cvar("bob_roll", "0.002", 0);
+	run_pitch = gi.cvar("run_pitch", "0.001", 0); //DdayChile - hAnS!! "0.002"
+	run_roll = gi.cvar("run_roll", "0.001", 0); //DdayChile - hAnS!! "0.005"
+	bob_up = gi.cvar("bob_up", "0.001", 0); //DdayChile - hAnS!! "0.005"
+	bob_pitch = gi.cvar("bob_pitch", "0.001", 0); //DdayChile - hAnS!! "0.002"
+	bob_roll = gi.cvar("bob_roll", "0.001", 0); //DdayChile - hAnS!! "0.002"
 
 	player_scores = gi.cvar("player_scores", "1", 0);//faf
 

--- a/g_weapon.c
+++ b/g_weapon.c
@@ -3800,7 +3800,7 @@ void Weapon_Sniper_Fire(edict_t* ent)
 	if (ent->client->aim)
 		VectorSet(offset, 0, 0, ent->viewheight);
 	else
-		VectorSet(offset, 0, 0, ent->viewheight - 8);
+		VectorSet(offset, 0, 0, ent->viewheight);// DdayChile hAnS!! ent->viewheight - 8
 
 	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
 
@@ -3818,7 +3818,7 @@ void Weapon_Sniper_Fire(edict_t* ent)
 		}
 	}
 	else
-		fire_gun(ent, start, forward, damage, kick, 100, 100, mod, false);
+		fire_gun(ent, start, forward, damage, kick, 40, 40, mod, false);//DdayChile hAnS!! 100,100
 
 	ent->client->sniper_loaded[ent->client->resp.team_on->index] = false;
 	// rezmoth - cosmetic recoil

--- a/p_client.c
+++ b/p_client.c
@@ -4383,7 +4383,7 @@ void Write_Player_Stats(edict_t* ent)
 	int castrations = 0;
 	int helmets = 0;
 	int fists = 0;
-	char* chat;
+    char* chat = NULL;
 
 	char	filename[MAX_QPATH] = "";
 
@@ -4610,11 +4610,7 @@ void Write_Player_Stats(edict_t* ent)
 
 	fclose(fn);
 
-	if (f)
-	{
-		free(f);
-		f = NULL;
-	}
+
 }
 
 //writes players stat average from .stat file to pers
@@ -4625,7 +4621,7 @@ void SetPlayerRating(edict_t* ent)
 
 	char* s, * f;
 
-	char* statsc;
+    char* statsc = NULL;
 
 	char* name;
 	/* float ratio = 0.0;  MetalGod initialized but not referenced */
@@ -4696,6 +4692,11 @@ void SetPlayerRating(edict_t* ent)
 		if (s != NULL) {
 			chat = s;
 			s = strtok(NULL, "\n");
+		}
+		if (f) //Ddaychile  se cambio de lugar este if para evitar el error al desconectar un player
+		{
+			free(f);
+			f = NULL;
 		}
 	}
 

--- a/p_view.c
+++ b/p_view.c
@@ -666,7 +666,7 @@ void SV_CalcGunOffset(edict_t* ent)
 	//stops binocular aim being messed up
 
 	// gun angles from bobbing
-	ent->client->ps.gunangles[ROLL] = xyspeed * bobfracsin * 0.005;
+	ent->client->ps.gunangles[ROLL] = xyspeed * bobfracsin * 0.001;//DdayChile hAnS!! 0.005
 	ent->client->ps.gunangles[YAW] = xyspeed * bobfracsin * 0.01;
 	if (bobcycle & 1)
 	{
@@ -674,7 +674,7 @@ void SV_CalcGunOffset(edict_t* ent)
 		ent->client->ps.gunangles[YAW] = -ent->client->ps.gunangles[YAW];
 	}
 
-	ent->client->ps.gunangles[PITCH] = xyspeed * bobfracsin * 0.005;
+	ent->client->ps.gunangles[PITCH] = xyspeed * bobfracsin * 0.001; //DdayChile hAnS!! 0.005
 
 	ent->client->ps.gunangles[YAW] = ent->client->ps.gunangles[YAW] + ent->client->crosshair_offset_x;
 	ent->client->ps.gunangles[PITCH] = ent->client->ps.gunangles[PITCH] + ent->client->crosshair_offset_y;
@@ -715,18 +715,19 @@ void SV_CalcGunOffset(edict_t* ent)
 		}
 	}
 
-	if (!chile->value && ent->client->last_jump_time > level.time - 3)
+	//DdayChile hAnS!!  esto estaba comentado anteriormente
+
+	/* if (!chile->value && ent->client->last_jump_time > level.time - 3)
 	{
 		if (ent->client->pers.weapon &&
 			ent->client->pers.weapon->classnameb != WEAPON_MP43)
 		{
-			if (4 * (level.time - ent->client->last_jump_time) < (3.1416F))/* MetalGod Make sure this is explicitly a float!*/
-			{
+			if (4 * (level.time - ent->client->last_jump_time) < (3.1416F))			{
 				ent->client->ps.gunangles[PITCH] =
-					ent->client->ps.gunangles[PITCH] - 8 * (sinf(4 * (level.time - ent->client->last_jump_time))); /* MetalGod use the float version of sin (sinf) No need for float precision !*/
+					ent->client->ps.gunangles[PITCH] - 8 * (sinf(4 * (level.time - ent->client->last_jump_time))); 
 			}
 		}
-	}
+	}*/
 
 	/*  make this a model change later
 	//faf:  mauser tweak
@@ -981,9 +982,9 @@ void SV_CalcBlend(edict_t* ent)
 
 	if (ent->client->ps.fov == SCOPE_FOV)
 		if (chile->value)
-			SV_AddBlend (0.0, 0.0, 0.0, .1, ent->client->ps.blend); // No blue tinge on DDay Chile - ZeRo
+			SV_AddBlend (0.0, 0.0, 0.0F, .1F, ent->client->ps.blend); // No blue tinge on DDay Chile - ZeRo
 		else
-			SV_AddBlend(0.0, 0.0, 0.25F, .1F, ent->client->ps.blend);//faf:  blue tinge /* MetalGod explicit float */
+			SV_AddBlend(0.0, 0.0, 0.0F, .1F, ent->client->ps.blend);//faf:  blue tinge /* MetalGod explicit float */
 //		SV_AddBlend (0.0, 0.0, 0.0, .1 + (xyspeed/1000), ent->client->ps.blend);
 		//end faf
 }
@@ -2409,15 +2410,15 @@ void ClientEndServerFrame(edict_t* ent)
 		bobmove = 0;
 		current_client->bobtime = 0;	// start at beginning of cycle again
 	}
-	else if (ent->groundentity)
-	{	// so bobbing only cycles when on ground
-		if (xyspeed > 210)
-			bobmove = 0.25;
-		else if (xyspeed > 100)
-			bobmove = 0.125;
-		else
-			bobmove = 0.0625;
-	}
+    else if (ent->groundentity)
+    {	// so bobbing only cycles when on ground
+    if (xyspeed > 210)  
+    bobmove = chile->value == 1 ? 0.1 : 0.25; //DdayChile hAnS!! 0.25
+    else if (xyspeed > 100)
+    bobmove = chile->value == 1 ? 0.1 : 0.125; //DdayChile hAnS!! 0.125
+    else
+    bobmove = chile->value == 1 ? 0.1 : 0.0625; //DdayChile hAnS!! 0.0625
+    }
 
 	bobtime = (current_client->bobtime += bobmove);
 


### PR DESCRIPTION
Se ha cambiado el comando del depurador local en `dday.vcxproj.user` para que apunte a `C:\Quake2\q2proded.exe` y se han ajustado los argumentos del comando.

En `g_save.c`, se han reducido los valores de las variables de movimiento en la función `InitGame`.

En `g_weapon.c`, se ha ajustado el retroceso del arma y se ha eliminado la reducción de `ent->viewheight` en `Weapon_Sniper_Fire`.

En `p_client.c`, se ha inicializado la variable `chat` a `NULL` en `Write_Player_Stats` y se ha movido la liberación de memoria en `SetPlayerRating`.

En `p_view.c`, se han ajustado los ángulos del arma y el efecto de balanceo en `SV_CalcGunOffset`, se ha comentado un bloque de código relacionado con el salto, se ha ajustado la mezcla de colores en `SV_CalcBlend` y se ha suavizado el movimiento de balanceo en `ClientEndServerFrame`.